### PR TITLE
Improve char to hex conversion

### DIFF
--- a/ahk_kostyli/kostyli.py
+++ b/ahk_kostyli/kostyli.py
@@ -34,7 +34,7 @@ def unescape_spec(string):
 
 def unicode_hex(string):
     # return ''.join(['&#{0};'.format(hex(ord(char))[2:]) for char in string])
-    return ''.join(['\\u00{0}'.format(hex(ord(char))[2:]) for char in string])
+    return ''.join(['\\u00{:02x}'.format(ord(char)) for char in string])
     
 def unicode_decode(string):
     return codecs.decode(string, 'unicode-escape')


### PR DESCRIPTION
Use format string syntax `'{:02x}'.format(ord(char))` instead of `'{0}'.format(hex(ord(char))[2:])`.